### PR TITLE
feat: support footnote macro conversion to Markdown footnotes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,7 @@ const ConumRx = /(^| )<([.1-9]|1\d)>(?=(?: <(?:[.1-9]|1\d)>)*$)/g
 const DlistItemRx = /^(?!\/\/)(\S.*?)(:{2,4})(?: (.+))?($)/
 const ElementAttributeRx = /(?:^|, *)(?:(\w[\w-]*)=)?(?:("|')(.+?)\2|([^,]+|))/g
 const EmphasisSpanMetaRx = /(?<![\p{L}\d_\\])\[[^[\]]+\](?=_(?:\S|\S.*?\S)_(?![\p{L}\d_]))/gu
+const FootnoteMacroRx = /(\\)?footnote:([^\s[]*)\[((?:\[(?:[^\]\\]|\\.)*\]|[^\]\\])*)\]/g
 const InlineAnchorRx = /\[\[([\p{L}_][\p{Alpha}\d_\-:.]*)\]\]/u
 const InlineImageMacroRx = /image:([^\s:`[\\][^[\\]*)\[(|.*?[^\\])\]/g
 const InlineStemMacroRx = /stem:\[(.*?[^\\])\]/g
@@ -297,12 +298,26 @@ module.exports = function downdoc (asciidoc, { attributes: initialAttrs = {} } =
       return '[' + (text || reftext) + '](#' + autoId + ')'
     })
     .concat((grab = verbatim?.cap) ? '\n' + grab : '')
+    .concat((grab = attrs.fnotes?.length)
+      ? '\n\n' + attrs.fnotes.map((fn, i) => '[^' + (i + 1) + ']: ' + fn.text).join('\n')
+      : '')
 }
 
 function applySubs (str, subs = NORMAL_SUBS) {
   if (!/[{\x60\x27*_:<[#]/.test(str)) return str
   if (subs.includes('macros') && ~str.indexOf('m:[')) {
     str = str.replace(InlineStemMacroRx, (_, expr) => 'stem:[' + (this.pass.push(expr.replace(/\\]/g, ']')) - 1) + ']')
+  }
+  if (subs.includes('macros') && ~str.indexOf('footnote:')) {
+    str = str.replace(FootnoteMacroRx, (m, esc, id, text) => {
+      if (esc) return m.substring(1)
+      const fnotes = (this.fnotes ??= [])
+      const fnotesById = (this.fnotesById ??= new Map())
+      if (id && !text && fnotesById.has(id)) return 'footnote:[' + fnotesById.get(id) + ']'
+      const num = fnotes.push({ text })
+      if (id) fnotesById.set(id, num)
+      return 'footnote:[' + num + ']'
+    })
   }
   return subs.reduce((str, name) => SUBSTITUTORS[name].call(this, str), str)
 }
@@ -343,6 +358,16 @@ function isHeading (str, acceptAll, blockAttrs, marker, title, spaceIdx = str.in
 function macros (str) {
   if (!~str.indexOf(':')) return ~str.indexOf('[[') ? str.replace(InlineAnchorRx, '<a name="$1"></a>') : str
   if (~str.indexOf('m:[')) str = str.replace(InlineStemMacroRx, (_, idx) => '$' + (this.pass[Number(idx)] || idx) + '$')
+  if (~str.indexOf('footnote:[')) {
+    str = str.replace(/footnote:\[(\d+)\]/g, (_, idx) => {
+      const entry = this.fnotes[Number(idx) - 1]
+      if (entry && !entry.resolved) {
+        entry.text = applySubs.call(this, entry.text)
+        entry.resolved = true
+      }
+      return '[^' + idx + ']'
+    })
+  }
   if (~str.indexOf('image:')) str = str.replace(InlineImageMacroRx, image.bind(this))
   if (~str.indexOf(':/') || ~str.indexOf('link:')) {
     str = str.replace(LinkMacroRx, (_, esc, scheme = '', url, boxed = '', text, bareScheme = scheme, bareUrl) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -308,16 +308,19 @@ function applySubs (str, subs = NORMAL_SUBS) {
   if (subs.includes('macros') && ~str.indexOf('m:[')) {
     str = str.replace(InlineStemMacroRx, (_, expr) => 'stem:[' + (this.pass.push(expr.replace(/\\]/g, ']')) - 1) + ']')
   }
-  if (subs.includes('macros') && ~str.indexOf('footnote:')) {
-    str = str.replace(FootnoteMacroRx, (m, esc, id, text) => {
-      if (esc) return m.substring(1)
-      const fnotes = (this.fnotes ??= [])
-      const fnotesById = (this.fnotesById ??= new Map())
-      if (id && !text && fnotesById.has(id)) return 'footnote:[' + fnotesById.get(id) + ']'
-      const num = fnotes.push({ text })
-      if (id) fnotesById.set(id, num)
-      return 'footnote:[' + num + ']'
-    })
+  if (subs.includes('macros')) {
+    const src = subs.includes('attributes') && ~str.indexOf('{') ? attributes.call(this, str) : str
+    if (~src.indexOf('footnote:')) {
+      str = src.replace(FootnoteMacroRx, (m, esc, id, text) => {
+        if (esc) return m.substring(1)
+        const fnotes = (this.fnotes ??= [])
+        const fnotesById = (this.fnotesById ??= new Map())
+        if (id && fnotesById.has(id)) return 'footnote:[' + fnotesById.get(id) + ']'
+        const num = fnotes.push({ text })
+        if (id) fnotesById.set(id, num)
+        return 'footnote:[' + num + ']'
+      })
+    }
   }
   return subs.reduce((str, name) => SUBSTITUTORS[name].call(this, str), str)
 }

--- a/test/downdoc-test.js
+++ b/test/downdoc-test.js
@@ -3919,6 +3919,154 @@ describe('downdoc()', () => {
     })
   })
 
+  describe('footnotes', () => {
+    it('should convert anonymous footnote macro', () => {
+      const input = heredoc`
+      = Title
+
+      The hail-and-rainbow protocol can be initiated at five levels.footnote:[The double hail-and-rainbow level makes my toes tingle.]
+      `
+      const expected = heredoc`
+      # Title
+
+      The hail-and-rainbow protocol can be initiated at five levels.[^1]
+
+      [^1]: The double hail-and-rainbow level makes my toes tingle.
+      `
+      assert.equal(downdoc(input), expected)
+    })
+
+    it('should convert multiple footnotes with consecutive numbering', () => {
+      const input = heredoc`
+      = Title
+
+      A bold statement!footnote:[Opinions are my own.]
+
+      Another statement.footnote:[More details here.]
+      `
+      const expected = heredoc`
+      # Title
+
+      A bold statement![^1]
+
+      Another statement.[^2]
+
+      [^1]: Opinions are my own.
+      [^2]: More details here.
+      `
+      assert.equal(downdoc(input), expected)
+    })
+
+    it('should convert named footnote and reuse it', () => {
+      const input = heredoc`
+      = Title
+
+      A bold statement!footnote:disclaimer[Opinions are my own.]
+
+      Another outrageous statement.footnote:disclaimer[]
+      `
+      const expected = heredoc`
+      # Title
+
+      A bold statement![^1]
+
+      Another outrageous statement.[^1]
+
+      [^1]: Opinions are my own.
+      `
+      assert.equal(downdoc(input), expected)
+    })
+
+    it('should apply normal substitutions to footnote text', () => {
+      const input = heredoc`
+      = Title
+
+      A bold statement!footnote:[This is *very* important.]
+      `
+      const expected = heredoc`
+      # Title
+
+      A bold statement![^1]
+
+      [^1]: This is **very** important.
+      `
+      assert.equal(downdoc(input), expected)
+    })
+
+    it('should convert URL macro inside footnote text', () => {
+      const input = heredoc`
+      = Title
+
+      See this.footnote:[Visit https://example.org[the site] for details.]
+      `
+      const expected = heredoc`
+      # Title
+
+      See this.[^1]
+
+      [^1]: Visit [the site](https://example.org) for details.
+      `
+      assert.equal(downdoc(input), expected)
+    })
+
+    it('should unescape escaped footnote macro', () => {
+      const input = heredoc`
+      = Title
+
+      Use \\footnote:[text] to insert a footnote.
+      `
+      const expected = heredoc`
+      # Title
+
+      Use footnote:[text] to insert a footnote.
+      `
+      assert.equal(downdoc(input), expected)
+    })
+
+    it('should not convert footnote macro in verbatim block', () => {
+      const input = heredoc`
+      = Title
+
+      ----
+      footnote:[This should not be converted.]
+      ----
+      `
+      const expected = heredoc`
+      # Title
+
+      \`\`\`
+      footnote:[This should not be converted.]
+      \`\`\`
+      `
+      assert.equal(downdoc(input), expected)
+    })
+
+    it('should place footnote definitions after all body content', () => {
+      const input = heredoc`
+      = Title
+
+      First paragraph.footnote:[First note.]
+
+      == Section
+
+      Second paragraph.footnote:[Second note.]
+      `
+      const expected = heredoc`
+      # Title
+
+      First paragraph.[^1]
+
+      ## Section
+
+      Second paragraph.[^2]
+
+      [^1]: First note.
+      [^2]: Second note.
+      `
+      assert.equal(downdoc(input), expected)
+    })
+  })
+
   describe('link and URL macros', () => {
     it('should convert URL macro', () => {
       const input = heredoc`

--- a/test/downdoc-test.js
+++ b/test/downdoc-test.js
@@ -1947,7 +1947,7 @@ describe('downdoc()', () => {
     it('should not promote first row to header if preceded by empty line', () => {
       const input = heredoc`
       |===
-      
+
       | A1
 
       | A2
@@ -4062,6 +4062,40 @@ describe('downdoc()', () => {
 
       [^1]: First note.
       [^2]: Second note.
+      `
+      assert.equal(downdoc(input), expected)
+    })
+
+    it('should convert footnote macro referenced via attribute', () => {
+      const input = heredoc`
+      = Title
+      :link-apply: https://example.org[Online form]footnote:[https://example.org]
+
+      Apply via {link-apply} today.
+      `
+      const expected = heredoc`
+      # Title
+
+      Apply via [Online form](https://example.org)[^1] today.
+
+      [^1]: https://example.org
+      `
+      assert.equal(downdoc(input), expected)
+    })
+
+    it('should reuse named footnote referenced via attribute', () => {
+      const input = heredoc`
+      = Title
+      :fn: seefootnote:note[https://example.org]
+
+      First {fn} and second {fn}.
+      `
+      const expected = heredoc`
+      # Title
+
+      First see[^1] and second see[^1].
+
+      [^1]: https://example.org
       `
       assert.equal(downdoc(input), expected)
     })


### PR DESCRIPTION
Fixes #35

This PR add the feature to convert AsciiDoc `footnote:[text]` macros to Markdown footnote syntax. Inline references become `[^N]` with consecutively assigned numbers. Footnote definitions are appended at the end of the document as `[^N]: text` lines.

Named footnotes (`footnote:id[text]`) are also supported, and back-references (`footnote:id[]`) reuse the same number as the first definition. Footnote text goes through full normal substitutions, including URL macros with bracketed labels. Escaped macros (`\footnote:`) pass through verbatim.

Also supports footnotes provided as part of attributes.