### PR TITLE
feat: support mailto: macro conversion to Markdown links

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,7 @@ const InlineImageMacroRx = /image:([^\s:`[\\][^[\\]*)\[(|.*?[^\\])\]/g
 const InlineStemMacroRx = /stem:\[(.*?[^\\])\]/g
 const LinkMacroRx = /(\\)?(?:(?:link:(?!:)|(https?:\/\/))([^\s[\\]+)(\[(|.*?[^\\])\^?\])|(https?:\/\/)([^\s[\]]+))/g
 const ListItemRx = /^(\*+|\.+|<(?:[.1-9]|1\d)>|-|\d+\.) +(.+)/
+const MailtoMacroRx = /(\\)?(?:link:)?mailto:([^\s[\\]+)\[(|.*?[^\\])\]/g
 const MarkedSpanRx = /(?<![\p{L}\d_\\])(?:\[((\.line-through)|[^[\]]+)\])?#(\S|\S.*?\S)#(?![\p{L}\d_])/gu
 const PreprocessorDirectiveRx = /^\\?(?:(if)(n)?def|include)::([^[]+)\[(.+)?\]$/
 const QuotedSpanRx = /("|')`(\S|\S.*?\S)`\1/g
@@ -344,6 +345,12 @@ function macros (str) {
   if (!~str.indexOf(':')) return ~str.indexOf('[[') ? str.replace(InlineAnchorRx, '<a name="$1"></a>') : str
   if (~str.indexOf('m:[')) str = str.replace(InlineStemMacroRx, (_, idx) => '$' + (this.pass[Number(idx)] || idx) + '$')
   if (~str.indexOf('image:')) str = str.replace(InlineImageMacroRx, image.bind(this))
+  if (~str.indexOf('mailto:')) {
+    str = str.replace(MailtoMacroRx, (m, esc, addr, text) => {
+      if (esc) return m.substring(1)
+      return '[' + (text || addr) + '](mailto:' + addr + ')'
+    })
+  }
   if (~str.indexOf(':/') || ~str.indexOf('link:')) {
     str = str.replace(LinkMacroRx, (_, esc, scheme = '', url, boxed = '', text, bareScheme = scheme, bareUrl) => {
       if (esc) return bareScheme ? '<span>' + bareScheme + '</span>' + (bareUrl ?? url + boxed) : 'link:' + url + boxed

--- a/test/downdoc-test.js
+++ b/test/downdoc-test.js
@@ -4146,6 +4146,76 @@ describe('downdoc()', () => {
       `
       assert.equal(downdoc(input), expected)
     })
+
+    it('should convert mailto macro with label', () => {
+      const input = heredoc`
+      = Title
+
+      Send a message to mailto:jane@example.com[Jane Doe].
+      `
+      const expected = heredoc`
+      # Title
+
+      Send a message to [Jane Doe](mailto:jane@example.com).
+      `
+      assert.equal(downdoc(input), expected)
+    })
+
+    it('should convert mailto macro with empty label', () => {
+      const input = heredoc`
+      = Title
+
+      Send a message to mailto:jane@example.com[].
+      `
+      const expected = heredoc`
+      # Title
+
+      Send a message to [jane@example.com](mailto:jane@example.com).
+      `
+      assert.equal(downdoc(input), expected)
+    })
+
+    it('should unescape escaped mailto macro', () => {
+      const input = heredoc`
+      = Title
+
+      Use \\mailto:jane@example.com[Jane Doe] to create an email link.
+      `
+      const expected = heredoc`
+      # Title
+
+      Use mailto:jane@example.com[Jane Doe] to create an email link.
+      `
+      assert.equal(downdoc(input), expected)
+    })
+
+    it('should not convert bare mailto address without brackets', () => {
+      const input = heredoc`
+      = Title
+
+      Contact us at mailto:jane@example.com for more information.
+      `
+      const expected = heredoc`
+      # Title
+
+      Contact us at mailto:jane@example.com for more information.
+      `
+      assert.equal(downdoc(input), expected)
+    })
+
+    it('should convert link macro with mailto target', () => {
+      const input = heredoc`
+      = Title
+
+      Send a message to link:mailto:jane@example.com[Jane Doe].
+      `
+      const expected = heredoc`
+      # Title
+
+      Send a message to [Jane Doe](mailto:jane@example.com).
+      `
+      assert.equal(downdoc(input), expected)
+    })
   })
 
   describe('image macros', () => {


### PR DESCRIPTION
Fixes #39 

This PR adds the support for converting AsciiDoc `mailto:addr[text]` macros to `[text](mailto:addr)` Markdown links. Also handles `mailto:addr[]` (empty label falls back to address) and the `link:mailto:addr[text]` form seen in the wild. Escaped macros (`\mailto:`) pass through verbatim.

Bare `mailto:addr` without brackets is left untouched. My understanding is that this is consistent with the AsciiDoc spec, but please correct me if I'm wrong.